### PR TITLE
Add input errors

### DIFF
--- a/checkout.php
+++ b/checkout.php
@@ -27,34 +27,36 @@
 												<label class="label--required">Full Name</label>
 											</td>
 											<td>
-												<input type="text" name="name" id="name" class="input--text u-fill" placeholder="Your full name" required>
+												<span class="input">
+													<input type="text" name="name" id="name" class="input--text u-fill" placeholder="Your full name" required>
+												</span>
 											</td>
 										</tr>
-									</tbody>
-									<tbody class="checkout__section">
 										<tr class="checkout__row">
 											<td>
 												<label class="label--required">Address</label>
 											</td>
 											<td>
-												<input type="text" name="address" id="address" class="input--text u-fill" placeholder="Delivery address" required>
+												<span class="input">
+													<input type="text" name="address" id="address" class="input--text u-fill" placeholder="Delivery address" required>
+												</span>
 											</td>
 										</tr>
-									</tbody>
-									<tbody class="checkout__section">
 										<tr class="checkout__row">
 											<td>
 												<label>Gender</label>
 											</td>
 											<td>
-												<label for="gender--men" class="label--radio u-inline-block u-m-medium--right">
-													<input type="radio" name="gender" value="men" id="gender--men" class="input--radio">
-													Women
-												</label>
-												<label for="gender--women" class="label--radio u-inline-block">
-													<input type="radio" name="gender" value="women" id="gender--women" class="input--radio">
-													Men
-												</label>
+												<span class="input">
+													<label for="gender--men" class="label--radio u-inline-block u-m-medium--right">
+														<input type="radio" name="gender" value="men" id="gender--men" class="input--radio">
+														Women
+													</label>
+													<label for="gender--women" class="label--radio u-inline-block">
+														<input type="radio" name="gender" value="women" id="gender--women" class="input--radio">
+														Men
+													</label>
+												</span>
 											</td>
 										</tr>
 										<tr class="checkout__row" class="label--required">
@@ -62,7 +64,9 @@
 												<label>Phone No.</label>
 											</td>
 											<td>
-												<input type="text" name="phone" id="phone" class="input--text u-fill" placeholder="Phone number" required>
+												<span class="input">
+													<input type="text" name="phone" id="phone" class="input--text u-fill" placeholder="Phone number" required>
+												</span>
 											</td>
 										</tr>
 										<tr class="checkout__row">
@@ -70,7 +74,10 @@
 												<label>Country</label>
 											</td>
 											<td>
-												<input type="text" name="country" id="country" class="input--text u-fill" placeholder="Country of residence">
+												<!-- <span class="popup">Input is invalid</span> -->
+												<span class="input">
+													<input type="text" name="country" id="country" class="input--text u-fill" placeholder="Country of residence">
+												</span>
 											</td>
 										</tr>
 										<tr class="checkout__row">
@@ -78,7 +85,9 @@
 												<label>Birthday</label>
 											</td>
 											<td>
-												<input type="date" name="birthday" id="birthday" class="input--date u-fill">
+												<span class="input">
+													<input type="date" name="birthday" id="birthday" class="input--date u-fill">
+												</span>
 											</td>
 										</tr>
 									</tbody>
@@ -100,7 +109,9 @@
 												<label class="label--required">Email</label>
 											</td>
 											<td>
-												<input type="text" name="email" id="email" class="input--text u-fill" placeholder="name@email.com">
+												<span class="input">
+													<input type="text" name="email" id="email" class="input--text u-fill" placeholder="name@email.com">
+												</span>
 											</td>
 										</tr>
 										<tr class="checkout__row u-is-hidden">
@@ -108,7 +119,9 @@
 												<label class="label--required">Password</label>
 											</td>
 											<td>
-												<input type="password" name="password" id="password" class="input--text u-fill" placeholder="Enter password">
+												<span class="input">
+													<input type="password" name="password" id="password" class="input--text u-fill" placeholder="Enter password">
+												</span>
 											</td>
 										</tr>
 										<tr class="checkout__row u-is-hidden">
@@ -116,7 +129,9 @@
 												<label class="label--required">Verify Password</label>
 											</td>
 											<td>
-												<input type="password" name="password--verify" id="password--verify" class="input--text u-fill" placeholder="Re-enter password">
+												<span class="input">
+													<input type="password" name="password--verify" id="password--verify" class="input--text u-fill" placeholder="Re-enter password">
+												</span>
 											</td>
 										</tr>
 									</tbody>
@@ -167,10 +182,12 @@
 											<label class="label--required">Card Type</label>
 										</td>
 										<td>
-											<select class="select u-fill">
-												<option value="visa">VISA</option>
-												<option value="mastercard">MasterCard</option>
-											</select>
+											<span class="input">
+												<select class="select u-fill">
+													<option value="visa">VISA</option>
+													<option value="mastercard">MasterCard</option>
+												</select>
+											</span>
 										</td>
 									</tr>
 									<tr class="checkout__row">
@@ -178,7 +195,9 @@
 											<label class="label--required">Card Number</label>
 										</td>
 										<td>
-											<input type="text" name="card-number" id="card-number" class="input--text u-fill" required>
+											<span class="input">
+												<input type="text" name="card-number" id="card-number" class="input--text u-fill" required>
+											</span>
 										</td>
 									</tr>
 									<tr class="checkout__row">
@@ -186,31 +205,33 @@
 											<label class="label--required">Expiry Date</label>
 										</td>
 										<td>
-											<div class="payment__expiry">
-												<select class="select u-m-medium--right u-flex-2">
-													<option value="January" selected="selected">January</option>
-													<option value="February">February</option>
-													<option value="March">March</option>
-													<option value="April">April</option>
-													<option value="May">May</option>
-													<option value="June">June</option>
-													<option value="July">July</option>
-													<option value="August">August</option>
-													<option value="September">September</option>
-													<option value="October">October</option>
-													<option value="November">November</option>
-													<option value="December">December</option>
-												</select>
-												<select class="select u-flex-1">
-													<!-- Day option is based on selected month -->
-													<option value="1" selected="selected">1</option>
-												</select>
-											</div>
+											<span class="input">
+												<div id="payment__expiry" class="payment__expiry">
+													<select class="select u-m-medium--right u-flex-2">
+														<option value="January" selected="selected">January</option>
+														<option value="February">February</option>
+														<option value="March">March</option>
+														<option value="April">April</option>
+														<option value="May">May</option>
+														<option value="June">June</option>
+														<option value="July">July</option>
+														<option value="August">August</option>
+														<option value="September">September</option>
+														<option value="October">October</option>
+														<option value="November">November</option>
+														<option value="December">December</option>
+													</select>
+													<select class="select u-flex-1">
+														<!-- Day option is based on selected month -->
+														<option value="1" selected="selected">1</option>
+													</select>
+												</div>
+											</span>
 										</td>
 									</tr>
 									<tr class="checkout__row">
 										<td>
-											<label class="label--required">VCC</label>
+											<label class="label--required">CVV</label>
 										</td>
 										<td>
 											<input type="text" name="vcc" id="vcc" class="input--text" required>

--- a/css/src/components.styl
+++ b/css/src/components.styl
@@ -446,6 +446,7 @@ section[id^=collection]
 
 .checkout__row td
 	padding size-s 0
+	vertical-align top
 
 .checkout__row td:nth-child(1)
 	padding-right size-s

--- a/css/src/objects.styl
+++ b/css/src/objects.styl
@@ -140,6 +140,16 @@
 	font-size sub-h1
 	margin-bottom size-xs
 
+.input--invalid input
+	border 1px solid color-red
+
+.input--invalid
+	color color-red
+
+.input::after
+	content attr(data-attr)
+	font-size sub-h2
+
 /**
  * Checkbox
  */
@@ -255,3 +265,16 @@
 	top 2rem
 	font-size h2
 	color color-dark-grey
+
+/**
+ * Popup
+ */
+
+.popup
+	position absolute
+	background color-white
+	padding size-xs size-m
+	font-size sub-h2
+	right 0
+	box-shadow()
+	border-radius()

--- a/css/src/tools.styl
+++ b/css/src/tools.styl
@@ -10,7 +10,7 @@ vendor(prop, args)
 border-radius(args = 4px)
 	vendor('border-radius', args)
 
-box-shadow(args = 0 size-xxs size-xxs 0 alpha(color-black, 0.125))
+box-shadow(args = 0 size-xs size-xs 0 alpha(color-black, 0.15))
 	vendor('box-shadow', args)
 
 transition(args = all 0.1s ease-out)

--- a/css/src/utilities.styl
+++ b/css/src/utilities.styl
@@ -59,3 +59,5 @@
 
 .u-is-hidden
 	display none !important
+.u-is-invalid
+	border 1px solid color-red

--- a/css/style.css
+++ b/css/style.css
@@ -310,6 +310,16 @@ button-moz-focusring,
   font-size: 0.875rem;
   margin-bottom: 0.25rem;
 }
+.input--invalid input {
+  border: 1px solid #cf000f;
+}
+.input--invalid {
+  color: #cf000f;
+}
+.input::after {
+  content: attr(data-attr);
+  font-size: 0.75rem;
+}
 .input--radio,
 .input--checkbox {
   width: 1em;
@@ -416,6 +426,19 @@ button-moz-focusring,
   font-size: 1.5rem;
   color: #678;
 }
+.popup {
+  position: absolute;
+  background: #fff;
+  padding: 0.25rem 1rem;
+  font-size: 0.75rem;
+  right: 0;
+  -webkit-box-shadow: 0 0.25rem 0.25rem 0 rgba(0,17,34,0.15);
+  -moz-box-shadow: 0 0.25rem 0.25rem 0 rgba(0,17,34,0.15);
+  box-shadow: 0 0.25rem 0.25rem 0 rgba(0,17,34,0.15);
+  -webkit-border-radius: 4px;
+  -moz-border-radius: 4px;
+  border-radius: 4px;
+}
 html {
   font-size: 100%;
   background: #012;
@@ -500,9 +523,9 @@ strong {
 }
 .nav {
   background: #fff;
-  -webkit-box-shadow: 0 0.125rem 0.125rem 0 rgba(0,17,34,0.125);
-  -moz-box-shadow: 0 0.125rem 0.125rem 0 rgba(0,17,34,0.125);
-  box-shadow: 0 0.125rem 0.125rem 0 rgba(0,17,34,0.125);
+  -webkit-box-shadow: 0 0.25rem 0.25rem 0 rgba(0,17,34,0.15);
+  -moz-box-shadow: 0 0.25rem 0.25rem 0 rgba(0,17,34,0.15);
+  box-shadow: 0 0.25rem 0.25rem 0 rgba(0,17,34,0.15);
   width: 100%;
   z-index: 1000;
 }
@@ -523,9 +546,9 @@ strong {
 .nav--tertiary {
   background: #fff;
   border-top: 1px solid rgba(0,17,34,0.125);
-  -webkit-box-shadow: 0 0.125rem 0.125rem 0 rgba(0,17,34,0.125);
-  -moz-box-shadow: 0 0.125rem 0.125rem 0 rgba(0,17,34,0.125);
-  box-shadow: 0 0.125rem 0.125rem 0 rgba(0,17,34,0.125);
+  -webkit-box-shadow: 0 0.25rem 0.25rem 0 rgba(0,17,34,0.15);
+  -moz-box-shadow: 0 0.25rem 0.25rem 0 rgba(0,17,34,0.15);
+  box-shadow: 0 0.25rem 0.25rem 0 rgba(0,17,34,0.15);
   position: absolute;
   width: 100%;
   z-index: 10;
@@ -926,6 +949,7 @@ section[id^=collection] {
 }
 .checkout__row td {
   padding: 0.5rem 0;
+  vertical-align: top;
 }
 .checkout__row td:nth-child(1) {
   padding-right: 0.5rem;
@@ -1082,4 +1106,7 @@ section[id^=collection] {
 }
 .u-is-hidden {
   display: none !important;
+}
+.u-is-invalid {
+  border: 1px solid #cf000f;
 }

--- a/js/global.js
+++ b/js/global.js
@@ -14,13 +14,17 @@ var HTML_LOGIN = `
 					<label for="email" class="label--required label--top">
 						Email
 					</label>
-					<input type="text" name="email" id="email" class="input--text u-fill" placeholder="name@email.com" required>
+					<span class="input">
+						<input type="text" name="email" id="email" class="input--text u-fill" placeholder="name@email.com" required>
+					</span>
 				</div>
 				<div class="u-m-large--bottom">
 					<label for="password" class="label--required label--top">
 						Password
 					</label>
-					<input type="password" name="password" id="password" class="input--text u-fill" placeholder="Enter password" required>
+					<span class="input">
+						<input type="password" name="password" id="password" class="input--text u-fill" placeholder="Enter password" required>
+					</span>
 				</div>
 				<div class="login__action">
 					<button type="submit" class="button button--primary button--large">
@@ -37,7 +41,7 @@ var HTML_LOGIN = `
 `;
 
 var HTML_REGISTER = `
-<div class="modal__window register">
+	<div class="modal__window register">
 		<div id="modal__close" class="modal__close">
 			<i class="material-icons">close</i>
 		</div>
@@ -49,19 +53,25 @@ var HTML_REGISTER = `
 						<label for="email" class="label--required label--top">
 							Email
 						</label>
-						<input type="text" name="email" id="email" class="input--text u-fill" placeholder="name@email.com" required>
+						<span class="input">
+							<input type="text" name="email" id="email" class="input--text u-fill" placeholder="name@email.com" required>
+						</span>
 					</div>
 					<div class="u-m-medium--bottom">
 						<label for="password" class="label--required label--top">
 							Password
 						</label>
-						<input type="password" name="password" id="password" class="input--text u-fill" placeholder="Enter password" required>
+						<span>
+							<input type="password" name="password" id="password" class="input--text u-fill" placeholder="Enter password" required>
+						</span>
 					</div>
 					<div class="u-m-large--bottom">
 						<label for="password--verify" class="label--required label--top">
 							Verify Password
 						</label>
-						<input type="password" name="password--verify" id="password--verify" class="input--text u-fill" placeholder="Re-enter password" required>
+						<span class="input">
+							<input type="password" name="password--verify" id="password--verify" class="input--text u-fill" placeholder="Re-enter password" required>
+						</span>
 					</div>
 					<div class="register__action">
 						<button type="button" class="button button--primary button--large" id="register__next">
@@ -82,7 +92,9 @@ var HTML_REGISTER = `
 									<label class="label--required">Full Name</label>
 								</td>
 								<td>
-									<input type="text" name="name" id="name" class="input--text u-fill" placeholder="Your full name" required>
+									<span class="input">
+										<input type="text" name="name" id="name" class="input--text u-fill" placeholder="Your full name" required>
+									</span>
 								</td>
 							</tr>
 							<tr class="checkout__row">
@@ -90,7 +102,9 @@ var HTML_REGISTER = `
 									<label class="label--required">Address</label>
 								</td>
 								<td>
-									<input type="text" name="address" id="address" class="input--text u-fill" placeholder="Delivery address" required>
+									<span class="input">
+										<input type="text" name="address" id="address" class="input--text u-fill" placeholder="Delivery address" required>
+									</span>
 								</td>
 							</tr>
 							<tr class="checkout__row">
@@ -113,7 +127,9 @@ var HTML_REGISTER = `
 									<label>Phone No.</label>
 								</td>
 								<td>
-									<input type="text" name="phone" id="phone" class="input--text u-fill" placeholder="Phone number" required>
+									<span class="input">
+										<input type="text" name="phone" id="phone" class="input--text u-fill" placeholder="Phone number" required>
+									</span>
 								</td>
 							</tr>
 							<tr class="checkout__row">
@@ -121,7 +137,9 @@ var HTML_REGISTER = `
 									<label>Country</label>
 								</td>
 								<td>
-									<input type="text" name="country" id="country" class="input--text u-fill" placeholder="Country of residence">
+									<span class="input">
+										<input type="text" name="country" id="country" class="input--text u-fill" placeholder="Country of residence">
+									</span>
 								</td>
 							</tr>
 							<tr class="checkout__row">
@@ -129,7 +147,9 @@ var HTML_REGISTER = `
 									<label>Birthday</label>
 								</td>
 								<td>
-									<input type="date" name="birthday" id="birthday" class="input--date u-fill">
+									<span class="input">
+										<input type="date" name="birthday" id="birthday" class="input--date u-fill">
+									</span>
 								</td>
 							</tr>
 						</tbody>
@@ -163,7 +183,7 @@ var spawn = function(content, target, parentClass, parentId, cb) {
 	el.innerHTML = content;
 	target.insertBefore(el, target.firstChild);
 
-	return cb(el);
+	if (cb) return cb(el);
 }
 
 var spawnModal = function(content) {
@@ -202,6 +222,48 @@ var spawnModal = function(content) {
 				console.log('click: register next');
 			};
 		});
+	}
+}
+
+/**
+ * Error with message
+ * Use this to show input error with a message
+ * Input must be nested inside a span.input (!)
+ * target  = any child element of span.input
+ * message = error string
+ */
+
+var showErrorWithMessage = function(target, message) {
+	if (target) {
+		target.parentNode.setAttribute('data-attr', message);
+		addClass(target.parentNode, 'input--invalid');
+	}
+	else console.log('No target found for showErrorWithMessage()');
+};
+
+var hideErrorWithMessage = function(target) {
+	if (target) {
+		target.parentNode.setAttribute('data-attr');
+		removeClass(target.parentNode, 'input--invalid');
+	}
+	else console.log('No target found for hideErrorWithMessage()');
+};
+
+/**
+ * Simple error
+ * Add red border to target element
+ * Applicable to any input field
+ * target  = input field
+ */
+
+var showSimpleError = function(target) {
+	if (target) {
+		addClass(target, 'u-is-invalid');
+	}
+}
+var hideSimpleError = function(target) {
+	if (target) {
+		removeClass(target, 'u-is-invalid');
 	}
 }
 

--- a/js/global.js
+++ b/js/global.js
@@ -243,7 +243,7 @@ var showErrorWithMessage = function(target, message) {
 
 var hideErrorWithMessage = function(target) {
 	if (target) {
-		target.parentNode.setAttribute('data-attr');
+		target.parentNode.setAttribute('data-attr', '');
 		removeClass(target.parentNode, 'input--invalid');
 	}
 	else console.log('No target found for hideErrorWithMessage()');

--- a/php/modal.login.php
+++ b/php/modal.login.php
@@ -9,13 +9,17 @@
 					<label for="email" class="label--required label--top">
 						Email
 					</label>
-					<input type="text" name="email" id="email" class="input--text u-fill" placeholder="name@email.com" required>
+					<span class="input">
+						<input type="text" name="email" id="email" class="input--text u-fill" placeholder="name@email.com" required>
+					</span>
 				</div>
 				<div class="u-m-large--bottom">
 					<label for="password" class="label--required label--top">
 						Password
 					</label>
-					<input type="password" name="password" id="password" class="input--text u-fill" placeholder="Enter password" required>
+					<span class="input">
+						<input type="password" name="password" id="password" class="input--text u-fill" placeholder="Enter password" required>
+					</span>
 				</div>
 				<div class="login__action">
 					<button type="submit" class="button button--primary button--large">

--- a/php/modal.register.php
+++ b/php/modal.register.php
@@ -10,19 +10,25 @@
 						<label for="email" class="label--required label--top">
 							Email
 						</label>
-						<input type="text" name="email" id="email" class="input--text u-fill" placeholder="name@email.com" required>
+						<span class="input">
+							<input type="text" name="email" id="email" class="input--text u-fill" placeholder="name@email.com" required>
+						</span>
 					</div>
 					<div class="u-m-medium--bottom">
 						<label for="password" class="label--required label--top">
 							Password
 						</label>
-						<input type="password" name="password" id="password" class="input--text u-fill" placeholder="Enter password" required>
+						<span class="input">
+							<input type="password" name="password" id="password" class="input--text u-fill" placeholder="Enter password" required>
+						</span>
 					</div>
 					<div class="u-m-large--bottom">
 						<label for="password--verify" class="label--required label--top">
 							Verify Password
 						</label>
-						<input type="password" name="password--verify" id="password--verify" class="input--text u-fill" placeholder="Re-enter password" required>
+						<span class="input">
+							<input type="password" name="password--verify" id="password--verify" class="input--text u-fill" placeholder="Re-enter password" required>
+						</span>
 					</div>
 					<div class="register__action">
 						<button type="button" class="button button--primary button--large" id="register__next">
@@ -43,7 +49,9 @@
 									<label class="label--required">Full Name</label>
 								</td>
 								<td>
-									<input type="text" name="name" id="name" class="input--text u-fill" placeholder="Your full name" required>
+									<span class="input">
+										<input type="text" name="name" id="name" class="input--text u-fill" placeholder="Your full name" required>
+									</span>
 								</td>
 							</tr>
 							<tr class="checkout__row">
@@ -51,15 +59,9 @@
 									<label class="label--required">Address</label>
 								</td>
 								<td>
-									<input type="text" name="address" id="address" class="input--text u-fill" placeholder="Delivery address" required>
-								</td>
-							</tr>
-							<tr class="checkout__row">
-								<td>
-									<label class="label--required">Postal Code</label>
-								</td>
-								<td>
-									<input type="text" name="postal-code" id="postal-code" class="input--text u-fill" placeholder="Postal code" required>
+									<span class="input">
+										<input type="text" name="address" id="address" class="input--text u-fill" placeholder="Delivery address" required>
+									</span>
 								</td>
 							</tr>
 							<tr class="checkout__row">
@@ -82,7 +84,9 @@
 									<label>Phone No.</label>
 								</td>
 								<td>
-									<input type="text" name="phone" id="phone" class="input--text u-fill" placeholder="Phone number" required>
+									<span class="input">
+										<input type="text" name="phone" id="phone" class="input--text u-fill" placeholder="Phone number" required>
+									</span>
 								</td>
 							</tr>
 							<tr class="checkout__row">
@@ -90,7 +94,9 @@
 									<label>Country</label>
 								</td>
 								<td>
-									<input type="text" name="country" id="country" class="input--text u-fill" placeholder="Country of residence">
+									<span class="input">
+										<input type="text" name="country" id="country" class="input--text u-fill" placeholder="Country of residence">
+									</span>
 								</td>
 							</tr>
 							<tr class="checkout__row">
@@ -98,7 +104,9 @@
 									<label>Birthday</label>
 								</td>
 								<td>
-									<input type="date" name="birthday" id="birthday" class="input--date u-fill">
+									<span class="input">
+										<input type="date" name="birthday" id="birthday" class="input--date u-fill">
+									</span>
 								</td>
 							</tr>
 						</tbody>


### PR DESCRIPTION
For inputs wrapped in a `span.input`
```showErrorWithMessage(target, message)```
```hideErrorWithMessage(target)```

For any `input` field
```showSimpleError(target)```
```hideSimpleError(target)```

Issue:
`showErrorWithMessage()` doesn't work on price--min and price--max due to additional layer to wrap the $ in the input field

add popup class
add u-is-invalid class
add input invalid with message
add show invalid input functions